### PR TITLE
Change the action verb in the headline 0007 - merge with careers-search-dev branch

### DIFF
--- a/frontend/src/components/TheHeadline.vue
+++ b/frontend/src/components/TheHeadline.vue
@@ -11,15 +11,23 @@ export default {
   data() {
     return {
       action: "Build",
+      interval: null,
     };
   },
   created() {
     this.changeTitle();
   },
+  beforeUnmount() {
+    clearInterval(this.interval);
+  },
   methods: {
     changeTitle() {
-      setInterval(() => {
+      this.interval = setInterval(() => {
         const actions = ["Build", "Create", "Design", "Code"];
+        const currentActionsIndex = actions.indexOf(this.action);
+        const nextActionIndex = (currentActionsIndex + 1) % 4;
+        const nextAction = actions[nextActionIndex];
+        this.action = nextAction;
       }, 3000);
     },
   },


### PR DESCRIPTION
Need to merge with the correct branch. Previous merge was with `main`. This one is with `careers-search-dev` branch.

I have changed the default github branch to `careers-search-dev`.


A `changeTitle()` method and `setInterval()` function were created in `TheHeadline.vue` to rotate among four action verbs to display in the headline.
The interval property that is set is destroyed when the component is unmounted.