### PR TITLE
Fix styles of primary header with css 0012

### DIFF
--- a/frontend/src/components/TheHeadline.vue
+++ b/frontend/src/components/TheHeadline.vue
@@ -1,6 +1,6 @@
 <template>
   <section>
-    <h1>
+    <h1 class="ml-14 text-8xl font-bold tracking-tighter">
       <span :class="actionClasses">{{ action }}</span>
       <br />
       for everyone


### PR DESCRIPTION
Added tailwind classes for large margin size, large font size, bold font, and tight tracking for the h1 primary header for TheHeadline.vue.

 - This PR closes #12 